### PR TITLE
Replace usages of =~ with `.match?` where possible

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -182,7 +182,7 @@ module Haml
 
       tabs = line.whitespace.length / @indentation.length
       return tabs if line.whitespace == @indentation * tabs
-      return @template_tabs + 1 if flat? && line.whitespace =~ /^#{@flat_spaces}/
+      return @template_tabs + 1 if flat? && /^#{@flat_spaces}/.match?(line.whitespace)
 
       message = Error.message(:inconsistent_indentation,
         human_indentation(line.whitespace),
@@ -630,7 +630,7 @@ module Haml
 
       tag_name, attributes, rest = match
 
-      if !attributes.empty? && (attributes =~ /[.#](\.|#|\z)/)
+      if !attributes.empty? && /[.#](\.|#|\z)/.match?(attributes)
         raise SyntaxError.new(Error.message(:illegal_element))
       end
 
@@ -786,7 +786,7 @@ module Haml
       line_defined = instance_variable_defined?(:@line)
       @line.tabs if line_defined
       unless (flat? && !closes_flat?(line) && !closes_flat?(@line)) ||
-          (line_defined && @line.text[0] == ?: && line.full =~ %r[^#{@line.full[/^\s+/]}\s])
+          (line_defined && @line.text[0] == ?: && %r[^#{@line.full[/^\s+/]}\s].match?(line.full))
         return next_line if line.text.empty?
 
         handle_multiline(line)
@@ -796,7 +796,7 @@ module Haml
     end
 
     def closes_flat?(line)
-      line && !line.text.empty? && line.full !~ /^#{@flat_spaces}/
+      line && !line.text.empty? && !(/^#{@flat_spaces}/.match?(line.full))
     end
 
     def handle_multiline(line)
@@ -814,7 +814,7 @@ module Haml
 
     # Checks whether or not `line` is in a multiline sequence.
     def is_multiline?(text)
-      text && text.length > 1 && text[-1] == MULTILINE_CHAR_VALUE && text[-2] == ?\s && text !~ BLOCK_WITH_SPACES
+      text && text.length > 1 && text[-1] == MULTILINE_CHAR_VALUE && text[-2] == ?\s && !BLOCK_WITH_SPACES.match?(text)
     end
 
     def handle_ruby_multiline(line)
@@ -838,7 +838,7 @@ module Haml
     # - and not "?\," which is a character literal
     def is_ruby_multiline?(text)
       text && text.length > 1 && text[-1] == ?, &&
-        !((text[-3, 2] =~ /\W\?/) || text[-3, 2] == "?\\")
+        !(/\W\?/.match?(text[-3, 2]) || text[-3, 2] == "?\\")
     end
 
     def balance(*args)
@@ -871,7 +871,7 @@ module Haml
     # Same semantics as block_opened?, except that block_opened? uses Line#tabs,
     # which doesn't interact well with filter lines
     def filter_opened?
-      @next_line.full =~ (@indentation ? /^#{@indentation * (@template_tabs + 1)}/ : /^\s/)
+      (@indentation ? /^#{@indentation * (@template_tabs + 1)}/ : /^\s/).match?(@next_line.full)
     end
 
     def flat?

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -252,7 +252,7 @@ MSG
       # From Ruby's parse.y
       return unless scanner.scan(/([^\s'":;]+)\s*:\s*("(?:\\.|[^"])*"|[^"\s;]+?)[\s;]*-\*-/n)
       name, val = scanner[1], scanner[2]
-      return unless name =~ /(en)?coding/in
+      return unless /(en)?coding/in.match?(name)
       val = $1 if val =~ /^"(.*)"$/n
       return val
     ensure


### PR DESCRIPTION
This commit updates the Haml parser and utility modules to consistently use Ruby's `Regexp#match?` instead of the `=~` operator for regular expression matching. `match?` is more idiomatic for predicate checks and does not require setting the global match variables, improving performance and code clarity.

No functional changes to parsing logic are intended with this refactor.